### PR TITLE
Fix Linux Release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Download AppImageTool
         run: |
           mkdir -p linux/build
-          wget -O linux/build/appimagetool https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+          wget -O linux/build/appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
           chmod +x linux/build/appimagetool
 
       - name: Create AppImage Structure


### PR DESCRIPTION
[AppImageKit](https://github.com/AppImage/AppImageKit) 已经被废弃，而且把 release assets 的名字都加了个前缀，导致下载 appimagetool 时 404。

把旧的 URI 改成新的，应该可以修复 Linux Release 的构建。